### PR TITLE
fix(seo): use path prop to build og:url

### DIFF
--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import useSiteMetadata from '../hooks/useSiteMetadata';
 
-function SEO({ description, title, titleTemplate }) {
+function SEO({ description, path, title, titleTemplate }) {
   const siteMetadata = useSiteMetadata();
   const seo = {
     title,
@@ -11,7 +11,7 @@ function SEO({ description, title, titleTemplate }) {
     description: description || siteMetadata.longDescription,
     socialImage: `${siteMetadata.siteUrl}${siteMetadata.socialImage}`,
     twitterImage: `${siteMetadata.siteUrl}${siteMetadata.twitterImage}`,
-    url: `${siteMetadata.siteUrl}`,
+    url: `${siteMetadata.siteUrl.concat(path)}`,
   };
 
   return (
@@ -42,15 +42,17 @@ function SEO({ description, title, titleTemplate }) {
   );
 }
 
-SEO.defaultProps = {
-  description: ``,
-  titleTemplate: ``,
-};
-
 SEO.propTypes = {
   description: PropTypes.string,
+  path: PropTypes.string,
   title: PropTypes.string.isRequired,
   titleTemplate: PropTypes.string,
+};
+
+SEO.defaultProps = {
+  description: ``,
+  path: ``,
+  titleTemplate: ``,
 };
 
 export default SEO;

--- a/src/templates/privacy.js
+++ b/src/templates/privacy.js
@@ -4,7 +4,7 @@ import { Container } from 'theme-ui';
 import Layout from '../components/Layout';
 import SEO from '../components/SEO';
 
-export default function Template({ data }) {
+export default function Template({ data, path }) {
   const title = `Política de Privacidade`;
   const { markdownRemark } = data;
   const { html, excerpt } = markdownRemark;
@@ -12,7 +12,7 @@ export default function Template({ data }) {
 
   return (
     <Layout>
-      <SEO description={description} title={title} />
+      <SEO description={description} path={path} title={title} />
       <Container dangerouslySetInnerHTML={{ __html: html }} />
     </Layout>
   );


### PR DESCRIPTION
Facebook's sharing debug to pointed that the meta tag `og:url` should have the same value as the input URL, therefore, we can just concatenate the path.