### PR TITLE
fix(header): use display:block to render properly on Safari mobile

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -14,7 +14,7 @@ const Header = () => {
   const toggleMode = () => setMode(mode === `light` ? `dark` : `light`);
 
   return (
-    <ThemeHeader>
+    <ThemeHeader sx={{ display: `block` }}>
       <Container
         as={Flex}
         sx={{


### PR DESCRIPTION
Closes #54.